### PR TITLE
Update Spring-Boot version to 2.0.3.RELEASE, kotlin deps to 1.2.51, e…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,8 @@ gradle-app.setting
 # gradle/wrapper/gradle-wrapper.properties
 
 # End of https://www.gitignore.io/api/osx,java,gradle,intellij
+
+.classpath
+.project
+.settings
+bin

--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,9 @@ buildscript {
     repositories(allRepositories)
 
     dependencies {
-        classpath "org.springframework.boot:spring-boot-gradle-plugin:1.5.8.RELEASE"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.21"
-        classpath "org.jetbrains.kotlin:kotlin-allopen:1.2.21"
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:2.0.3.RELEASE"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.51"
+        classpath "org.jetbrains.kotlin:kotlin-allopen:1.2.51"
     }
 }
 
@@ -22,6 +22,7 @@ apply plugin: 'kotlin'
 apply plugin: 'kotlin-spring'
 apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
+apply plugin: 'io.spring.dependency-management'
 
 group = 'de.bringmeister'
 version = '0.1.0'
@@ -34,14 +35,17 @@ compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 
+/**
 configurations {
     all*.exclude group: 'ch.qos.logback', module: 'logback-classic'
     all*.exclude module: 'commons-logging'
 }
+*/
+
 
 dependencies {
 
-    compile 'org.springframework.boot:spring-boot-starter-log4j2'
+    // compile 'org.springframework.boot:spring-boot-starter-log4j2'
     compile 'org.springframework.boot:spring-boot-starter-web'
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.21"
     compile "org.jetbrains.kotlin:kotlin-reflect:1.2.21"
@@ -51,8 +55,8 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.7'
 
     testCompile 'org.springframework.boot:spring-boot-starter-test'
-    testCompile 'com.nhaarman:mockito-kotlin:1.5.0'
-    testCompile "org.assertj:assertj-core:3.9.1"
+    // testCompile 'com.nhaarman:mockito-kotlin:1.5.0'
+    // testCompile "org.assertj:assertj-core:3.9.1"
 }
 
 sourceSets {

--- a/src/main/kotlin/de/bringmeister/connect/product/Application.kt
+++ b/src/main/kotlin/de/bringmeister/connect/product/Application.kt
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.scheduling.annotation.EnableAsync
 
 @SpringBootApplication
-@EnableAutoConfiguration
+// @EnableAutoConfiguration
 @EnableAsync
 class Application
 


### PR DESCRIPTION
…xclude log4j2

I was only able to get it to work with an update of Spring-Boot.
Unfortunately I had to remove/disable usage of log4j2 (tests failed with an StackOverflow, don't know why yet).
But it's possible to see in the logs that `@Async` is working now and every event-listener is executed/processed in a separat thread.

Regards